### PR TITLE
Added control headers so demos work out of box

### DIFF
--- a/examples/advanced/advanced.go
+++ b/examples/advanced/advanced.go
@@ -34,6 +34,16 @@ import (
 	"github.com/jcuga/golongpoll"
 )
 
+// Avoid XMLHTTPRequest errors
+func addCorsHeaders(fn http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		fn(w, r)
+	}
+}
+
 func main() {
 	manager, err := golongpoll.StartLongpoll(golongpoll.Options{
 		LoggingEnabled:                 true,
@@ -48,9 +58,9 @@ func main() {
 	// Serve our example driver webpage
 	http.HandleFunc("/advanced", AdvancedExampleHomepage)
 	// Serve handler that generates events
-	http.HandleFunc("/advanced/user/action", getUserActionHandler(manager))
+	http.HandleFunc("/advanced/user/action", addCorsHeaders(getUserActionHandler(manager)))
 	// Serve handler that subscribes to events.
-	http.HandleFunc("/advanced/events", getEventSubscriptionHandler(manager))
+	http.HandleFunc("/advanced/events", addCorsHeaders(getEventSubscriptionHandler(manager)))
 	// Start webserver
 	fmt.Println("Serving webpage at http://127.0.0.1:8081/advanced")
 	http.ListenAndServe("127.0.0.1:8081", nil)

--- a/examples/basic/basic.go
+++ b/examples/basic/basic.go
@@ -35,6 +35,16 @@ import (
 	"github.com/jcuga/golongpoll"
 )
 
+// Avoid XMLHTTPRequest errors
+func addCorsHeaders(fn http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		fn(w, r)
+	}
+}
+
 func main() {
 	manager, err := golongpoll.StartLongpoll(golongpoll.Options{
 		LoggingEnabled: true,
@@ -48,8 +58,10 @@ func main() {
 	go generateRandomEvents(manager)
 	// Serve our basic example driver webpage
 	http.HandleFunc("/basic", BasicExampleHomepage)
+
 	// Serve our event subscription web handler
-	http.HandleFunc("/basic/events", manager.SubscriptionHandler)
+	http.HandleFunc("/basic/events", addCorsHeaders(manager.SubscriptionHandler))
+
 	fmt.Println("Serving webpage at http://127.0.0.1:8081/basic")
 	http.ListenAndServe("127.0.0.1:8081", nil)
 


### PR DESCRIPTION
**Issue**
Attempting to run the demos out of box will fail due to errors with the AJAX request (tested with Chrome 52)

Sample error
```
XMLHttpRequest cannot load http://127.0.0.1:8081/basic/events?
timeout=45&category=farm&since_time=1471491258748. No 'Access-Control-Allow-Origin' header is 
present on the requested resource. Origin 'http://localhost:8081' is therefore not allowed access.
```

**Solution**
Add CORS headers to resolve