### PR TITLE
Add X-Content-Type-Options header to prevent MIME sniffing

### DIFF
--- a/longpoll.go
+++ b/longpoll.go
@@ -219,6 +219,7 @@ func getLongPollSubscriptionHandler(maxTimeoutSeconds int, subscriptionRequests 
 		}
 		// We are going to return json no matter what:
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		// Don't cache response:
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1.
 		w.Header().Set("Pragma", "no-cache")                                   // HTTP 1.0.


### PR DESCRIPTION
Add X-Content-Type-Options to prevent MIME sniffing vulnerabilities and make some browsers always accept the application/json Content-Type no matter what the JSON contains